### PR TITLE
check for more types

### DIFF
--- a/env.go
+++ b/env.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	envTag       = "env"
-	formatTag    = "env"
+	formatTag    = "format"
 	yamlFileType = "yaml"
 	envFileType  = "env"
 )


### PR DESCRIPTION
This PR includes:

- check if the environment variable contains an empty value. if yes then continue
- update bind function logic to check for my types including `time.Time`, `*time.Time`, and `time.Duration`. 

When reading for  a time field, it expects an extra struct tag name `format` to parse the time properly otherwise it uses a default `"2006-01-02T15:04:05"` 

It also allows for pointer check but I don't know if we actually want to go that route. For instance, check if a `fieldValue` is of type `*int32` or `int32`. This would require more lines of code.