### PR TITLE
enabled default value

### DIFF
--- a/env.go
+++ b/env.go
@@ -9,13 +9,12 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"gopkg.in/yaml.v3"
 )
 
 const (
 	envTag       = "env"
 	formatTag    = "format"
+	defaultTag   = "default"
 	yamlFileType = "yaml"
 	envFileType  = "env"
 )
@@ -33,7 +32,7 @@ func GetEnv(key string) string {
 	return os.Getenv(key)
 }
 
-func lookUpEnv(key string) (string, bool) {
+func LookUpEnv(key string) (string, bool) {
 	return os.LookupEnv(key)
 }
 
@@ -100,9 +99,12 @@ func bind(envStruct interface{}) error {
 
 		field := v.Type().Field(i).Tag.Get(envTag)
 
-		envFieldValue, ok := lookUpEnv(field)
+		envFieldValue, ok := LookUpEnv(field)
 		if !ok || envFieldValue == "" {
-			continue
+			envFieldValue = v.Type().Field(i).Tag.Get(defaultTag)
+			if envFieldValue == "" {
+				continue
+			}
 		}
 
 		currentFieldValue := reflect.Indirect(v).Field(i).Interface()


### PR DESCRIPTION
If you set the `default` tag for something, this value will be used in the case of absence of it in the environment.
<img width="160" alt="Screenshot 2023-06-20 at 22 56 58" src="https://github.com/nade-harlow/butler/assets/77660863/a0b123fe-ae19-4bed-b7de-6acfab5d882b">
<img width="474" alt="Screenshot 2023-06-20 at 22 54 01" src="https://github.com/nade-harlow/butler/assets/77660863/bd84a802-dc9c-4299-97d3-6b4cc2260738">
<img width="500" alt="Screenshot 2023-06-20 at 22 56 36" src="https://github.com/nade-harlow/butler/assets/77660863/722bebaf-456d-4baf-809c-2dd3c275cde9">
#9 